### PR TITLE
fix(tmux): work-around tmux being unable to tell Tab & C+i apart

### DIFF
--- a/files/conf/alacritty.toml
+++ b/files/conf/alacritty.toml
@@ -70,8 +70,14 @@ style = "Regular"
 x = 0
 y = 0
 
+# https://github.com/neovim/neovim/issues/20126#issuecomment-1296039900
+# https://github.com/tmux/tmux/issues/2705#issuecomment-1518520942
+# https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
+# https://gist.github.com/ConnerWill/d4b6c776b509add763e17f9f113fd25b#keyboard-strings
+# Make "C-i" send "F12 Tab". Then from tmux we send the `CSI u`-encoded
+# version of "C-i" ("\x1b[105;5u").
 [[keyboard.bindings]]
-chars = "\u001B[105;5u"
+chars = "\u001B[24~\t" # '\u001B' is Escape, '24' is F12, '\t' is Tab
 key = "I"
 mods = "Control"
 

--- a/files/conf/tmux.conf
+++ b/files/conf/tmux.conf
@@ -17,6 +17,24 @@ set -g terminal-overrides ",alacritty:RGB"
 
 set -g @resurrect-processes '~dune ~utop.exe'
 
+# Predicate to check if the current window_name is either vim, nvim, or
+# git. We include git because "automatic-rename" sets the name to "git" if we
+# run "git commit --amend".
+VIMLIKE="#{m/r:.*vim|git,#{window_name}}"
+
+# To get around some of tmux's quirks, we have to use a `virt` key-table.
+# This makes it so that we can distinguish, e.g., Tab vs C-i from the root
+# key-table. C-i from the root actually sends `F12 Tab` from wezterm, which
+# activates the `virt` key-table, and from there the Tab key sends the
+# `CSI u`-encoded form of C-i.
+
+bind-key -T root         F12        set key-table virt
+bind-key -T virt         F12        set key-table root
+
+# Buggy keys in tmux where there is no way to disambiguate these keys from TAB or RET.
+# https://github.com/tmux/tmux/issues/2705#issuecomment-1518520942
+bind-key -T virt         C-i        if-shell -F $VIMLIKE "send-keys Escape '[105;5u'" "send-keys -H 09" \; set key-table root
+
 # Plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'


### PR DESCRIPTION
I use this for neovim's jump-table functionaity.